### PR TITLE
`format!` append introduces an unnecessary heap allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- Remove unnecessary heap allocation ([#2](https://github.com/EmbarkStudios/tracing-logfmt/pull/2))
+
 ## [0.1.1] - 2022-06-15
 ### Fixed
-- Fix dependency status link in README.md
+- Fix dependency status link in README.md ([#1](https://github.com/EmbarkStudios/tracing-logfmt/pull/1))
 
 ## [0.1.0] - 2022-06-15
 ### Added

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,6 +1,15 @@
+use std::fmt::Write;
+
 #[derive(Debug, PartialEq)]
 pub enum SerializerError {
     InvalidKey,
+    FmtError,
+}
+
+impl From<std::fmt::Error> for SerializerError {
+    fn from(_: std::fmt::Error) -> Self {
+        SerializerError::FmtError
+    }
 }
 
 /// Serializes key/value pairs into logfmt format.
@@ -49,7 +58,7 @@ impl Serializer {
 
     fn serialize_value(&mut self, value: &str) -> Result<(), SerializerError> {
         if value.chars().any(Self::need_quote) {
-            self.output += &format!(r#""{}""#, value.escape_debug());
+            write!(self.output, r#""{}""#, value.escape_debug())?;
         } else {
             self.output += value;
         }


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
