### PR TITLE
Improve performance and reduce allocations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 //! dispatcher::set_global_default(Dispatch::new(subscriber))
 //!     .expect("Global logger has already been set!");
 //! ```
+
+#![deny(unreachable_pub)]
+
 mod formatter;
 mod serializer;
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,7 +1,7 @@
-use std::fmt::Write;
+use std::fmt;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum SerializerError {
+pub(crate) enum SerializerError {
     InvalidKey,
     FmtError,
 }
@@ -13,61 +13,114 @@ impl From<std::fmt::Error> for SerializerError {
 }
 
 /// Serializes key/value pairs into logfmt format.
-pub struct Serializer {
-    pub output: String,
+pub(crate) struct Serializer<W> {
+    pub(crate) writer: W,
+    writing_first_entry: bool,
 }
 
-impl Default for Serializer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Serializer {
-    pub fn new() -> Self {
+impl<W> Serializer<W>
+where
+    W: fmt::Write,
+{
+    #[inline]
+    pub(crate) fn new(writer: W) -> Self {
         Serializer {
-            output: String::new(),
+            writer,
+            writing_first_entry: true,
         }
     }
 
-    pub fn serialize_entry(&mut self, key: &str, value: &str) -> Result<(), SerializerError> {
-        if !self.output.is_empty() {
-            self.output += " ";
-        }
+    pub(crate) fn serialize_entry(
+        &mut self,
+        key: &str,
+        value: &str,
+    ) -> Result<(), SerializerError> {
+        self.serialize_entry_with(key, value, |this, value| this.serialize_value(value))
+    }
 
+    pub(crate) fn serialize_entry_no_quote(
+        &mut self,
+        key: &str,
+        value: impl fmt::Debug,
+    ) -> Result<(), SerializerError> {
+        self.serialize_entry_with(key, value, |this, value| {
+            this.serialize_value_no_quote(value)
+        })
+    }
+
+    fn serialize_entry_with<F, T>(
+        &mut self,
+        key: &str,
+        value: T,
+        serialize_value: F,
+    ) -> Result<(), SerializerError>
+    where
+        F: FnOnce(&mut Self, T) -> Result<(), SerializerError>,
+    {
         self.serialize_key(key)?;
-        self.output += "=";
-        self.serialize_value(value)?;
+        self.writer.write_char('=')?;
+        serialize_value(self, value)?;
 
         Ok(())
     }
 
-    fn serialize_key(&mut self, key: &str) -> Result<(), SerializerError> {
-        let key: &str = &key
-            .chars()
-            .filter(|&ch| !Self::need_quote(ch))
-            .collect::<String>();
+    pub(crate) fn serialize_key(&mut self, key: &str) -> Result<(), SerializerError> {
+        if !self.writing_first_entry {
+            self.writer.write_char(' ')?;
+        }
+        self.writing_first_entry = false;
 
-        if key.is_empty() {
+        let mut chars = key.chars().filter(|&ch| !need_quote(ch)).peekable();
+
+        if chars.peek().is_none() {
             return Err(SerializerError::InvalidKey);
         }
 
-        self.output += key;
+        for c in chars {
+            self.writer.write_char(c)?;
+        }
+
         Ok(())
     }
 
     fn serialize_value(&mut self, value: &str) -> Result<(), SerializerError> {
-        if value.chars().any(Self::need_quote) {
-            write!(self.output, r#""{}""#, value.escape_debug())?;
+        if value.chars().any(need_quote) {
+            self.writer.write_char('"')?;
+            write!(self.writer, "{}", value.escape_debug())?;
+            self.writer.write_char('"')?;
         } else {
-            self.output += value;
+            self.writer.write_str(value)?;
         }
 
         Ok(())
     }
 
-    fn need_quote(ch: char) -> bool {
-        ch <= ' ' || matches!(ch, '=' | '"')
+    fn serialize_value_no_quote(&mut self, value: impl fmt::Debug) -> Result<(), SerializerError> {
+        write!(self.writer, "{:?}", value)?;
+        Ok(())
+    }
+}
+
+#[inline]
+fn need_quote(ch: char) -> bool {
+    ch <= ' ' || matches!(ch, '=' | '"')
+}
+
+impl<W> std::io::Write for Serializer<W>
+where
+    W: fmt::Write,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if let Ok(buf) = std::str::from_utf8(buf) {
+            self.writer
+                .write_str(buf)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 
@@ -77,11 +130,12 @@ mod tests {
 
     #[test]
     fn test_serialize_entries() {
-        let mut s = Serializer::new();
+        let mut output = String::new();
+        let mut s = Serializer::new(&mut output);
         assert!(s.serialize_entry("key", "value").is_ok());
         assert!(s.serialize_entry("key2", "value2").is_ok());
 
-        assert_eq!(s.output, "key=value key2=value2");
+        assert_eq!(output, "key=value key2=value2");
     }
 
     #[test]
@@ -95,9 +149,10 @@ mod tests {
         ];
 
         for ((k, v), expected_output) in tests {
-            let mut s = Serializer::new();
+            let mut output = String::new();
+            let mut s = Serializer::new(&mut output);
             assert!(s.serialize_entry(k, v).is_ok());
-            assert_eq!(s.output, expected_output,);
+            assert_eq!(output, expected_output,);
         }
     }
 
@@ -111,10 +166,12 @@ mod tests {
             ("k\ney", "key"),
         ];
         for (input, expected_output) in tests {
-            let mut s = Serializer::new();
+            let mut output = String::new();
+
+            let mut s = Serializer::new(&mut output);
             assert!(s.serialize_key(input).is_ok());
 
-            assert_eq!(s.output, expected_output);
+            assert_eq!(output, expected_output);
         }
     }
 
@@ -128,7 +185,8 @@ mod tests {
         ];
 
         for (input, expected_error) in tests {
-            let mut s = Serializer::new();
+            let mut output = String::new();
+            let mut s = Serializer::new(&mut output);
             assert_eq!(s.serialize_key(input), Err(expected_error));
         }
     }
@@ -152,10 +210,11 @@ mod tests {
         ];
 
         for (input, expected_output) in tests {
-            let mut s = Serializer::new();
+            let mut output = String::new();
+            let mut s = Serializer::new(&mut output);
             assert!(s.serialize_value(input).is_ok());
 
-            assert_eq!(s.output, expected_output);
+            assert_eq!(output, expected_output);
         }
     }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Hello 👋 These changes improve performance and reduce allocations quite a bit. Mostly by writing directly to the underlying writers rather than intermediate strings. The code is slightly less clean but maintains most of the previous structure.

#### The numbers

Baseline using version from crates.io:
```
time=601.537292ms
allocations=4.700.014
```

After these changes:
```
time=283.841666ms
allocations=70.0014
```

Benchmark script I used:

```rust
use std::time::Instant;

use alloc_counter::AllocCounterSystem;
use tracing::*;
use tracing_logfmt::{EventsFormatter, FieldsFormatter};

#[global_allocator]
static A: AllocCounterSystem = AllocCounterSystem;

fn main() {
    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
        .event_format(EventsFormatter)
        .fmt_fields(FieldsFormatter)
        .with_writer(std::io::sink)
        .finish();

    tracing::subscriber::with_default(subscriber, || {
        let start = Instant::now();

        let ((allocations, _, _), _) = alloc_counter::count_alloc(|| {
            for _ in 0..100_000 {
                info!("message");
                {
                    let _span = info_span!("one", a = 1, b = 2).entered();
                    info!("message in span");
                    {
                        let _span = info_span!("two", a = 1, b = 2).entered();
                        info!("message in span");
                    }
                }
                debug!(a = 1, b = 2, c = false, "message with fields");
            }
        });

        println!("time={:?}", start.elapsed());
        println!("allocations={allocations}");
    });
}
```