### PR TITLE
Configurable extra fields

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,54 @@
+use tracing::Subscriber;
+use tracing_subscriber::{registry::LookupSpan, Layer};
+
+use crate::{EventsFormatter, FieldsFormatter};
+
+pub struct Builder {
+    pub(crate) events: EventsFormatter,
+    pub(crate) fields: FieldsFormatter,
+}
+
+pub fn builder() -> Builder {
+    Builder::new()
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Self {
+            events: EventsFormatter::default(),
+            fields: FieldsFormatter::default(),
+        }
+    }
+
+    pub fn with_level(mut self, enable: bool) -> Self {
+        self.events.with_level = enable;
+        self
+    }
+    pub fn with_target(mut self, enable: bool) -> Self {
+        self.events.with_target = enable;
+        self
+    }
+    pub fn with_span_name(mut self, enable: bool) -> Self {
+        self.events.with_span_name = enable;
+        self
+    }
+    pub fn with_span_path(mut self, enable: bool) -> Self {
+        self.events.with_span_path = enable;
+        self
+    }
+
+    pub fn build<S>(self) -> impl Layer<S>
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        tracing_subscriber::fmt::layer()
+            .event_format(self.events)
+            .fmt_fields(self.fields)
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -181,6 +181,7 @@ where
 
 /// A formatter that formats span fields into logfmt.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct FieldsFormatter {}
 
 impl<'writer> FormatFields<'writer> for FieldsFormatter {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,3 +1,5 @@
+pub(crate) mod builder;
+
 use std::fmt::{self, Write};
 
 use tracing::field::Visit;

--- a/src/formatter/builder.rs
+++ b/src/formatter/builder.rs
@@ -8,6 +8,20 @@ pub struct Builder {
     fields: FieldsFormatter,
 }
 
+/// Create a builder that can be used to configure the formatter.
+///
+/// Example:
+/// ```rust
+/// use tracing::dispatcher::{self, Dispatch};
+/// use tracing_subscriber::Registry;
+/// use tracing_subscriber::layer::SubscriberExt;
+///
+/// let subscriber = Registry::default()
+///     .with(tracing_logfmt::builder().with_span_path(false).layer());
+///
+/// dispatcher::set_global_default(Dispatch::new(subscriber))
+///     .expect("Global logger has already been set!");
+/// ```
 pub fn builder() -> Builder {
     Builder::new()
 }

--- a/src/formatter/builder.rs
+++ b/src/formatter/builder.rs
@@ -1,5 +1,5 @@
 use tracing::Subscriber;
-use tracing_subscriber::{registry::LookupSpan, Layer};
+use tracing_subscriber::{fmt::SubscriberBuilder, registry::LookupSpan, Layer};
 
 use crate::{EventsFormatter, FieldsFormatter};
 
@@ -37,11 +37,17 @@ impl Builder {
         self
     }
 
-    pub fn build<S>(self) -> impl Layer<S>
+    pub fn layer<S>(self) -> impl Layer<S>
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
         tracing_subscriber::fmt::layer()
+            .event_format(self.events)
+            .fmt_fields(self.fields)
+    }
+
+    pub fn subscriber_builder(self) -> SubscriberBuilder<FieldsFormatter, EventsFormatter> {
+        tracing_subscriber::fmt::Subscriber::builder()
             .event_format(self.events)
             .fmt_fields(self.fields)
     }

--- a/src/formatter/builder.rs
+++ b/src/formatter/builder.rs
@@ -4,8 +4,8 @@ use tracing_subscriber::{registry::LookupSpan, Layer};
 use crate::{EventsFormatter, FieldsFormatter};
 
 pub struct Builder {
-    pub(crate) events: EventsFormatter,
-    pub(crate) fields: FieldsFormatter,
+    events: EventsFormatter,
+    fields: FieldsFormatter,
 }
 
 pub fn builder() -> Builder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,8 @@
 
 #![deny(unreachable_pub)]
 
-mod builder;
 mod formatter;
 mod serializer;
 
-pub use crate::builder::builder;
+pub use crate::formatter::builder::builder;
 pub use crate::formatter::{layer, EventsFormatter, FieldsFormatter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@
 
 #![deny(unreachable_pub)]
 
+mod builder;
 mod formatter;
 mod serializer;
 
+pub use crate::builder::builder;
 pub use crate::formatter::{layer, EventsFormatter, FieldsFormatter};


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Makes it possible to disable extra fields like `span` and `span_path` in log output.

### Related Issues

Fixes #6 
