### PR TITLE
return fmt Layer instead of the layer trait

### DIFF
--- a/src/formatter/builder.rs
+++ b/src/formatter/builder.rs
@@ -1,5 +1,8 @@
 use tracing::Subscriber;
-use tracing_subscriber::{fmt::SubscriberBuilder, registry::LookupSpan, Layer};
+use tracing_subscriber::{
+    fmt::{Layer, SubscriberBuilder},
+    registry::LookupSpan,
+};
 
 use crate::{EventsFormatter, FieldsFormatter};
 
@@ -51,7 +54,7 @@ impl Builder {
         self
     }
 
-    pub fn layer<S>(self) -> impl Layer<S>
+    pub fn layer<S>(self) -> Layer<S, FieldsFormatter, EventsFormatter>
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Change the return type of `Builder::layer()` from `impl Layer<S>` to the actual implemented type of the layer that is created (`tracing_subscriber::fmt::Layer<S, FieldsFormatter, EventsFormatter>`). So that one can use the methods on that type (same as we already do for the `subscriber_builder`).
