### PR TITLE
Make `Builder` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,5 @@
 mod formatter;
 mod serializer;
 
-pub use crate::formatter::builder::builder;
+pub use crate::formatter::builder::{builder, Builder};
 pub use crate::formatter::{layer, EventsFormatter, FieldsFormatter};


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Makes the `Builder` type public. It wasn't previously so the retur value from
`tracing_logfmt::builder()` couldn't be named and you couldn't see the docs for
it.
