### PR TITLE
Add support for disabling ansi color when the feature is enabled

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -502,7 +502,7 @@ mod tests {
 
         let content = mock_writer.get_content();
 
-        // assert that ther is no ansi color sequences
+        // assert that there is no ansi color sequences
         assert_eq!(
             content,
             "level=info target=tracing_logfmt::formatter::tests message=message\n"

--- a/src/formatter/builder.rs
+++ b/src/formatter/builder.rs
@@ -61,6 +61,15 @@ impl Builder {
         self.events.with_module_path = enable;
         self
     }
+    pub fn with_timestamp(mut self, enable: bool) -> Self {
+        self.events.with_timestamp = enable;
+        self
+    }
+    #[cfg(feature = "ansi_logs")]
+    pub fn with_ansi_color(mut self, enable: bool) -> Self {
+        self.events.with_ansi_color = enable;
+        self
+    }
 
     pub fn layer<S>(self) -> Layer<S, FieldsFormatter, EventsFormatter>
     where


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds support for disabling ansi colors (via `with_ansi_color`) when the `ansi_logs` feature is enabled. It also defaults to only emitting colors if stdout is a terminal.

I also added `with_timestamp`, so it is possible to disable timestamps, mainly to make it easier to write tests.

### Related Issues

Fixes #15 
