### PR TITLE
thread_id: retrun 0 on unsupported targets

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -74,9 +74,8 @@ fn default_enable_ansi_color() -> bool {
 
 /// Gets the current thread id as an integer
 ///
-/// This only supports the normal platforms here, I doubt this crate has wide usage,
-/// we just hard compile fail if targeting a platform we don't implement so
-/// that it is obvious
+/// This only supports the normal platforms here (Linux, Windows, Apple).
+/// For anything else like WASM we just return 0.
 ///
 /// Note that a Rust `ThreadId` is actually just a process specific atomic,
 /// completely unrelated to the thread id assigned by the operating system, but
@@ -120,6 +119,15 @@ fn current_thread_id() -> u64 {
         }
 
         id
+    }
+
+    #[cfg(not(any(
+        any(target_os = "linux", target_os = "android"),
+        target_os = "windows",
+        target_vendor = "apple"
+    )))]
+    {
+        0
     }
 }
 

--- a/src/formatter/builder.rs
+++ b/src/formatter/builder.rs
@@ -77,6 +77,9 @@ impl Builder {
         self
     }
 
+    /// Enable emitting the thread id in log output.
+    ///
+    /// Note: On unsupported targets like WASM, the thread id will be `0`.
     pub fn with_thread_ids(mut self, enable: bool) -> Self {
         self.events.with_thread_ids = enable;
         self


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Make the thread_id function return 0 on unsupported platforms so that this crate can be used. The thread_id is off by default anyways. Added a note in the documentation.

### Related Issues

- #20